### PR TITLE
Tests & f32 functions truly round to/from 0 to 1

### DIFF
--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -15,7 +15,7 @@ def to_f32(img):
     except (ValueError, AssertionError):
         raise ValueError('Scaling to 0,1 requires unsigned integers')
 
-    one = dtype_info.max + 1
+    one = dtype_info.max
     return np.float32(img / one)
 
 
@@ -35,7 +35,7 @@ def f32_to_bgr(f_img, color=[1, 1, 1]):
     # Give the image a color dimension
     f_vol = f_img[:, :, np.newaxis]
     f_bgr = np.repeat(f_vol, 3, 2) * color
-    return (256 * f_bgr).astype(np.uint8)
+    return np.round(255 * f_bgr).astype(np.uint8)
 
 
 def linear_bgr(channels):

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -190,12 +190,12 @@ def test_color_red(channel_low_med_high, range_all, color_red):
 
 def test_color_khaki(channel_low_med_high, range_all, color_khaki):
     '''Blend an image with one channel, testing khaki color
-    Colors of any lightness/chroma should map low uint16 input values to 0
+    Colors of any lightness/chroma should map low uint16 input values to 1
     '''
 
     expected = np.uint8([
         [[0, 0, 0]],
-        [[0, 0, 0]],
+        [[1, 1, 1]],
         [[140, 230, 240]]
     ])
 
@@ -234,7 +234,7 @@ def test_multi_channel(channel_check, channel_check_inverse, range_all,
                        color_blue, color_yellow):
     '''Test blending an image with multiple channels'''
 
-    expected = 127 * np.uint8([
+    expected = 128 * np.uint8([
         [color_yellow, color_blue],
         [color_blue, color_yellow],
     ])

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -67,8 +67,8 @@ def colors(request):
 def f32_channel_low_med_high():
     return np.float32([
         [0.0],
-        [256.0 / 65536.0],
-        [65535.0 / 65536.0],
+        [256.0 / 65535.0],
+        [1.0],
     ])
 
 


### PR DESCRIPTION
fixes #11 

- The unit tests now assume rounding instead of truncation
- `f32_to_bgr` now rounds instead of truncates

fixes #4
- The unit tests now assume a float32 range that includes 1.0
- `to_f32` and `f32_to_bgr` now use a float32 range that includes 1.0