### PR TITLE
Correct Integer min/max threshholding

### DIFF
--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -1,43 +1,6 @@
 import numpy as np
 
 
-def to_f32(img):
-    '''Scale the dynamic range to 0.0 - 1.0
-
-    Arguments:
-    img: An integer image
-    '''
-
-    # No well-defined behavior for decimal values or values less than 0
-    try:
-        dtype_info = np.iinfo(img.dtype)
-        assert dtype_info.min is 0
-    except (ValueError, AssertionError):
-        raise ValueError('Scaling to 0,1 requires unsigned integers')
-
-    one = dtype_info.max
-    return np.float32(img / one)
-
-
-def f32_to_bgr(f_img, color=[1, 1, 1]):
-    '''Reshape into a color image
-
-    Arguments:
-    f_img: float32 image to reshape
-    '''
-
-    # All inputs should be normalized between 0 and 1
-    try:
-        assert np.all((f_img >= 0) & (f_img <= 1))
-    except AssertionError:
-        raise ValueError('Color image requires values from 0,1')
-
-    # Give the image a color dimension
-    f_vol = f_img[:, :, np.newaxis]
-    f_bgr = np.repeat(f_vol, 3, 2) * color
-    return np.round(255 * f_bgr).astype(np.uint8)
-
-
 def linear_bgr(channels):
     '''Blend all channels given
     Arguments:

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -9,7 +9,7 @@ def threshhold_image(image, min_, max_):
         max_: values here become max_ - min_
     '''
     # Set all values outside of range to zero
-    image[(image < min_) | (image > max_)] = min_
+    np.clip(image, min_, max_, out=image)
     image -= min_
 
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -25,7 +25,7 @@ def scale_color(color, range_):
     return 255 * color / range_
 
 
-def read_channel(channel):
+def handle_channel(channel):
     """
     Arguments:
         channel: Dict to blend with rendering settings:
@@ -87,7 +87,7 @@ def linear_bgr(channels):
     image_buffer = np.zeros(shape, dtype=np.float32)
 
     # threshhold images and normalize colors
-    images_colors = map(read_channel, channels)
+    images_colors = map(handle_channel, channels)
     images_colors = list(images_colors)
     total = len(images_colors)
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -1,6 +1,59 @@
 import numpy as np
 
 
+def threshhold_image(image, min_, max_):
+    ''' Use only pixel values above min_ below max_
+    Arguments:
+        image: ndarray modified in place
+        min_: values here become zero
+        max_: values here become max_ - min_
+    '''
+    # Set all values outside of range to zero
+    image[(image < min_) | (image > max_)] = min_
+    image -= min_
+
+
+def scale_color(color, range_):
+    ''' Color becomes conversion from inputs
+    Arguments:
+        color: b, g, r float array within 0, 1
+        range_: extent of input range
+    Returns:
+        Color conversion from inputs to 0, 255
+    '''
+    # Embed conversion within colors
+    return 255 * color / range_
+
+
+def read_channel(channel):
+    """
+    Arguments:
+        channel: Dict to blend with rendering settings:
+            {
+                image: Numpy image data
+                color: N-channel by b, g, r float32 color
+                min: Range minimum, float32 range
+                max: Range maximum, float32 range
+            }
+
+    Returns:
+        Threshholded image values between min and max
+        Scaled color to convert image to 24-bit BGR
+    """
+    image = channel['image']
+    color = channel['color']
+    input_limit = np.iinfo(image.dtype).max
+
+    # Translate min and max to image integers
+    min_ = int(round(channel['min'] * input_limit))
+    max_ = int(round(channel['max'] * input_limit))
+
+    # Prepare image and color for averaging
+    threshhold_image(image, min_, max_)
+    color_ = scale_color(color, max_ - min_)
+    return (image, color_)
+
+
 def linear_bgr(channels):
     '''Blend all channels given
     Arguments:
@@ -34,33 +87,21 @@ def linear_bgr(channels):
     image_buffer = np.zeros(shape, dtype=np.float32)
 
     # threshhold images and normalize colors
-    for channel in channels:
-        color = channel['color']
-        image = channel['image']
-        input_limit = np.iinfo(image.dtype).max
-
-        # Translate min and max to image integers
-        min_ = int(round(channel['min'] * input_limit))
-        max_ = int(round(channel['max'] * input_limit))
-        # Apply normalization to colors
-        color *= 255 / len(channels)
-        color /= (max_ - min_)
-
-        # Set all values outside of range to zero
-        image[(image < min_) | (image > max_)] = min_
-        image -= min_
+    images_colors = map(read_channel, channels)
+    images_colors = list(images_colors)
+    total = len(images_colors)
 
     # colorize image
     for color_idx in range(3):
-        for channel in channels:
-            color = channel['color']
-            image = channel['image']
+        for image, color in images_colors:
 
             # Add color for one channel in image buffer
             image_buffer += image * color[color_idx]
 
+        np.round(image_buffer/total, out=image_buffer)
+
         # Write to output and reset buffer
-        image_out[:, :, color_idx] = np.uint8(np.round(image_buffer))
+        image_out[:, :, color_idx] = np.uint8(image_buffer)
         image_buffer *= 0
 
     return image_out

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -2,8 +2,6 @@
 
 import pytest
 import numpy as np
-from minerva_lib.blend import to_f32
-from minerva_lib.blend import f32_to_bgr
 from minerva_lib.blend import linear_bgr
 
 
@@ -61,15 +59,6 @@ def color_khaki():
                         'color_blue', 'color_red', 'color_khaki'])
 def colors(request):
     return request.getfixturevalue(request.param)
-
-
-@pytest.fixture
-def f32_channel_low_med_high():
-    return np.float32([
-        [0.0],
-        [256.0 / 65535.0],
-        [1.0],
-    ])
 
 
 @pytest.fixture
@@ -286,57 +275,3 @@ def test_channel_size_zero():
     with pytest.raises(ValueError,
                        match=r'At least one channel must be specified'):
         linear_bgr([])
-
-
-def test_to_f32_full(channel_low_med_high, f32_channel_low_med_high):
-    ''' Test conversion to f32 across uint16 range'''
-
-    expected = f32_channel_low_med_high
-    result = to_f32(channel_low_med_high)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_to_f32_float_input(f32_channel_low_med_high):
-    '''Test supplying floating points when unsigned integers are expected'''
-
-    with pytest.raises(ValueError,
-                       match=r'Scaling to 0,1 requires unsigned integers'):
-        to_f32(f32_channel_low_med_high)
-
-
-def test_f32_to_bgr_white(channel_low_med_high, f32_channel_low_med_high):
-    ''' Test conversion from f32 to black, gray, white'''
-
-    expected = np.uint8([
-        [[0, 0, 0]],
-        [[1, 1, 1]],
-        [[255, 255, 255]]
-    ])
-
-    result = f32_to_bgr(f32_channel_low_med_high)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_f32_to_bgr_yellow(color_yellow, channel_low_med_high,
-                           f32_channel_low_med_high):
-    ''' Test conversion from f32 to yellow gradient'''
-
-    expected = np.uint8([
-        [[0, 0, 0]],
-        [[0, 1, 1]],
-        [[0, 255, 255]]
-    ])
-
-    result = f32_to_bgr(f32_channel_low_med_high, color_yellow)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_f32_to_bgr_int_input(channel_low_med_high):
-    '''Test supplying floating points when unsigned integers are expected'''
-
-    with pytest.raises(ValueError,
-                       match=r'Color image requires values from 0,1'):
-        f32_to_bgr(channel_low_med_high)

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -178,7 +178,7 @@ def test_range_low(channel_low_med_high, color_white, range_low):
     expected = np.uint8([
         [[0, 0, 0]],
         [[255, 255, 255]],
-        [[0, 0, 0]]
+        [[255, 255, 255]]
     ])
 
     result = linear_bgr([{
@@ -252,13 +252,13 @@ def test_color_khaki(channel_low_med_high, range_all, color_khaki):
 
 def test_color_khaki_range_low(channel_low_med_high, range_low, color_khaki):
     '''Blend an image with one channel, testing khaki at low range
-    Colors of any lightness/chroma should map inputs above threshhold to 0
+    Colors of any lightness/chroma should max out inputs above threshhold
     '''
 
     expected = np.uint8([
         [[0, 0, 0]],
         [[140, 230, 240]],
-        [[0, 0, 0]]
+        [[140, 230, 240]]
     ])
 
     result = linear_bgr([{

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -2,7 +2,20 @@
 
 import pytest
 import numpy as np
+from minerva_lib.blend import threshhold_image
+from minerva_lib.blend import handle_channel
+from minerva_lib.blend import scale_color
 from minerva_lib.blend import linear_bgr
+
+
+@pytest.fixture
+def half_uint16():
+    return int(32768)
+
+
+@pytest.fixture
+def full_uint16():
+    return int(65535)
 
 
 @pytest.fixture
@@ -80,6 +93,45 @@ def channel_check_inverse():
         [65535, 0],
         [0, 65535]
     ])
+
+
+def test_scale_color(color_white, half_uint16, full_uint16):
+    '''Make color into conversion factor from uint16 to uint8 bgr'''
+
+    expected = np.float32([255, 255, 255]) / 32767
+
+    result = scale_color(color_white, full_uint16 - half_uint16)
+
+    np.testing.assert_array_equal(expected, result)
+
+
+def test_threshhold_image(channel_low_med_high, half_uint16, full_uint16):
+    '''Threshhold image within upper half of the unsigned 16-bit range'''
+
+    expected = np.uint16([[0], [0], [32767]])
+
+    threshhold_image(channel_low_med_high, half_uint16, full_uint16)
+
+    np.testing.assert_array_equal(expected, channel_low_med_high)
+
+
+def test_handle_channel(channel_low_med_high, color_white, range_high):
+    '''Extract scaled color and threshholded image from channel dictionary'''
+
+    expected = (
+        np.uint16([[0], [0], [32767]]),
+        np.float32([255, 255, 255]) / 32767
+    )
+
+    result = handle_channel({
+        'image': channel_low_med_high,
+        'color': color_white,
+        'min': range_high[0],
+        'max': range_high[1]
+    })
+
+    np.testing.assert_array_equal(expected[0], result[0])
+    np.testing.assert_array_equal(expected[1], result[1])
 
 
 def test_range_all(channel_low_med_high, color_white, range_all):


### PR DESCRIPTION
Closes #8 

 - Min and max thresholding is done on integers
     - Works directly on input images
 - Colorizing and averaging continue to use float32 buffer
     - Float32 range is between 0,255 instead of 0,1
         - `to_f32` and `f32_to_bgr` functions now obselete
     - Reuses single addition buffer for b, g, and r

Closes #16 by [implementing correct clamping](https://github.com/sorgerlab/minerva-lib-python/pull/13/commits/aa2fea8f3cded2ab9d98dbacd0ed1de43342dc29)
