### PR TITLE
Fix clipping, additive blending, color order

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description-file = README.md
 license-file = LICENSE
-version = 0.1.0
+version = 0.0.1
 
 [aliases]
 test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description-file = README.md
 license-file = LICENSE
-version = 0.0.1
+version = 0.1.0
 
 [aliases]
 test=pytest

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -64,4 +64,4 @@ def linear_rgb(channels):
 
     # Return gamma correct image within 0, 1
     np.clip(out_buffer, 0, 1, out=out_buffer)
-    return out_buffer
+    return skimage.exposure.adjust_gamma(out_buffer, 1 / 2.2)

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -3,21 +3,23 @@ import skimage.exposure
 
 
 def composite_channel(a, image, color, range_min, range_max, out=None):
-    ''' Yield 3 image channels for r, g, b
+    ''' Composite given image _a_ with rendered channel _image_
 
-    Arguments:
-        a: Previously composited 2D image
-        image: Numpy 2D image data of any type
+    To update _a_ destructively, pass the same array to _a_ and _out_.
+
+    Args:
+        a: Numpy array to composite
+        image: Numpy array of channel to render and composite
         color: Color as r, g, b float32 array within 0, 1
         range_min: Threshhold range minimum, float32 within 0, 1
         range_max: Threshhold range maximum, float32 within 0, 1
-        out: Optional output array in which to place the result. To update\
- a destructively, pass the same array to a and out.
+        out: Optional output numpy array in which to place the result.
 
     Returns:
-        An array with the same shape as a containing the composited image.\
- If an output array is specified, a reference to out is returned.
+        A numpy array with the same shape as the composited image.
+        If an output array is specified, a reference to _out_ is returned.
     '''
+
     if out is None:
         out = a.copy()
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -27,7 +27,7 @@ def clip_image(channel):
     return f32_image, channel['color']
 
 
-def make_rgb(image, color):
+def composite_channel(image, color):
     ''' Yield 3 image channels for r, g, b
 
     Arguments:
@@ -42,7 +42,7 @@ def make_rgb(image, color):
         yield image * scalar
 
 
-def linear_rgb(channels):
+def composite_channels(channels):
     '''Blend all channels into one normalized image
 
     Arguments:
@@ -73,7 +73,7 @@ def linear_rgb(channels):
             out_buffer = np.zeros(out_shape, dtype=np.float32)
 
         # Add all three channels to output buffer
-        rgb_image = make_rgb(image, color)
+        rgb_image = composite_channel(image, color)
         out_buffer[:, :, 0] += next(rgb_image)
         out_buffer[:, :, 1] += next(rgb_image)
         out_buffer[:, :, 2] += next(rgb_image)

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -8,6 +8,7 @@ def handle_channel(channel):
         channel: Dict to blend with rendering settings:
             {
                 image: Numpy image data
+                color: r, g, b float32 array within 0, 1
                 min: Range minimum, float32 range 0, 1
                 max: Range maximum, float32 range 0, 1
             }
@@ -44,7 +45,7 @@ def linear_rgb(channels):
     for image, color in map(handle_channel, channels):
 
         num_channels += 1
-        if num_channels is 1:
+        if num_channels == 1:
             # Needs image to be 2D ndarray
             out_shape = image.shape + (3,)
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -9,7 +9,7 @@ def threshhold_image(image, min_, max_):
         max_: values here become max_ - min_
     '''
     # Set all values outside of range to zero
-    image[(image < min_) | (image > max_)] = min_
+    np.clip(image, min_, max_, out=image)
     image -= min_
 
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -29,7 +29,7 @@ def handle_channel(channel):
     return f32_image, channel['color']
 
 
-def linear_bgr(channels):
+def linear_rgb(channels):
     '''Blend all channels given
     Arguments:
         channels: List of dicts of channels to blend with rendering settings:

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -2,12 +2,13 @@ import numpy as np
 import skimage.exposure
 
 
-def handle_channel(channel):
-    '''
+def clip_image(channel):
+    ''' Clip an image from min, max to 0,1
+
     Arguments:
         channel: Dict to blend with rendering settings:
             {
-                image: Numpy image data
+                image: Numpy 2D image data
                 color: r, g, b float32 array within 0, 1
                 min: Range minimum, float32 range 0, 1
                 max: Range maximum, float32 range 0, 1
@@ -17,6 +18,7 @@ def handle_channel(channel):
         Threshholded float32 image normalzied within 0, 1
         r, g, b float32 array color within 0, 1
     '''
+
     f32_range = (channel['min'], channel['max'])
     f32_image = skimage.img_as_float(channel['image'])
 
@@ -25,8 +27,24 @@ def handle_channel(channel):
     return f32_image, channel['color']
 
 
+def make_rgb(image, color):
+    ''' Yield 3 image channels for r, g, b
+
+    Arguments:
+        image: Numpy 2D image data
+        color: r, g, b float32 array within 0, 1
+
+    Yields:
+        Numpy 2D image data for r, g, b channels
+    '''
+
+    for scalar in color:
+        yield image * scalar
+
+
 def linear_rgb(channels):
-    '''Blend all channels given
+    '''Blend all channels into one normalized image
+
     Arguments:
         channels: List of dicts of channels to blend with rendering settings:
             {
@@ -39,24 +57,26 @@ def linear_rgb(channels):
     Returns:
         float32 y by x by r, g, b color image within 0, 1
     '''
+
     num_channels = 0
 
-    # threshhold images and normalize colors
-    for image, color in map(handle_channel, channels):
+    # rescaled images and normalized colors
+    for image, color in map(clip_image, channels):
 
         num_channels += 1
         if num_channels == 1:
+
             # Needs image to be 2D ndarray
             out_shape = image.shape + (3,)
 
             # Output buffer for blending
             out_buffer = np.zeros(out_shape, dtype=np.float32)
 
-        # Additive blending for RGB buffer
-        for idx, scalar in enumerate(color):
-
-            # Add color for one channel in image buffer
-            out_buffer[:, :, idx] += image * scalar
+        # Add all three channels to output buffer
+        rgb_image = make_rgb(image, color)
+        out_buffer[:, :, 0] += next(rgb_image)
+        out_buffer[:, :, 1] += next(rgb_image)
+        out_buffer[:, :, 2] += next(rgb_image)
 
     # Must be at least one channel
     if num_channels < 1:

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -39,7 +39,7 @@ def linear_rgb(channels):
             }
 
     Returns:
-        float32 y by x by r, g, b gamma-corrected color image within 0, 1
+        float32 y by x by r, g, b color image within 0, 1
     '''
     num_channels = 0
 

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -45,9 +45,8 @@ def linear_rgb(channels):
 
         num_channels += 1
         if num_channels is 1:
-            # Compatible with images, vectors, or single pixels
-            in_shape = iter(image.shape)
-            out_shape = [next(in_shape, i) for i in [1, 1, 3]]
+            # Needs image to be 2D ndarray
+            out_shape = image.shape + (3,)
 
             # Output buffer for blending
             out_buffer = np.zeros(out_shape, dtype=np.float32)

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -1,57 +1,32 @@
 import numpy as np
 
 
-def threshhold_image(image, min_, max_):
-    ''' Use only pixel values above min_ below max_
-    Arguments:
-        image: ndarray modified in place
-        min_: values here become zero
-        max_: values here become max_ - min_
-    '''
-    # Set all values outside of range to zero
-    np.clip(image, min_, max_, out=image)
-    image -= min_
-
-
-def scale_color(color, range_):
-    ''' Color becomes conversion from inputs
-    Arguments:
-        color: b, g, r float array within 0, 1
-        range_: extent of input range
-    Returns:
-        Color conversion from inputs to 0, 255
-    '''
-    # Embed conversion within colors
-    return 255 * color / range_
-
-
 def handle_channel(channel):
-    """
+    '''
     Arguments:
         channel: Dict to blend with rendering settings:
             {
                 image: Numpy image data
-                color: N-channel by b, g, r float32 color
-                min: Range minimum, float32 range
-                max: Range maximum, float32 range
+                min: Range minimum, float32 range 0, 1
+                max: Range maximum, float32 range 0, 1
             }
 
     Returns:
-        Threshholded image values between min and max
-        Scaled color to convert image to 24-bit BGR
-    """
+        Threshholded float32 image values within 0,1
+        r, g, b float32 array color within 0, 1
+    '''
     image = channel['image']
-    color = channel['color']
     input_limit = np.iinfo(image.dtype).max
 
     # Translate min and max to image integers
-    min_ = int(round(channel['min'] * input_limit))
-    max_ = int(round(channel['max'] * input_limit))
+    min_ = channel['min'] * input_limit
+    max_ = channel['max'] * input_limit
 
-    # Prepare image and color for averaging
-    threshhold_image(image, min_, max_)
-    color_ = scale_color(color, max_ - min_)
-    return (image, color_)
+    # Return image for additive blending
+    f32_image = np.float32(channel['image']) - min_
+    np.clip(f32_image / (max_ - min_), 0, 1, out=f32_image)
+
+    return f32_image, channel['color']
 
 
 def linear_bgr(channels):
@@ -60,48 +35,33 @@ def linear_bgr(channels):
         channels: List of dicts of channels to blend with rendering settings:
             {
                 image: Numpy image data
-                color: N-channel by b, g, r float32 color
-                min: Range minimum, float32 range
-                max: Range maximum, float32 range
+                color: r, g, b float32 array within 0, 1
+                min: Range minimum, float32 range 0, 1
+                max: Range maximum, float32 range 0, 1
             }
 
     Returns:
-        uint8 y by x by 3 color BGR image
+        float32 y by x by r, g, b color image within 0, 1
     '''
+    num_channels = 0
 
-    # Get the number of channels
-    num_channels = len(channels)
+    # threshhold images and normalize colors
+    for image, color in map(handle_channel, channels):
+
+        num_channels += 1
+        if num_channels is 1:
+            # Output buffer for blending
+            out_shape = image.shape + (3,)
+            out_buffer = np.zeros(out_shape, dtype=np.float32)
+
+        # Additive blending for RGB buffer
+        for idx, scalar in enumerate(color):
+
+            # Add color for one channel in image buffer
+            out_buffer[:, :, idx] += image * scalar
 
     # Must be at least one channel
     if num_channels < 1:
         raise ValueError('At least one channel must be specified')
 
-    # Ensure that dimensions of all channels are equal
-    shape = channels[0]['image'].shape
-    for channel in channels:
-        if channel['image'].shape != shape:
-            raise ValueError('All channel images must have equal dimensions')
-
-    # Final output and buffer for blending
-    image_out = np.zeros(shape + (3,), dtype=np.uint8)
-    image_buffer = np.zeros(shape, dtype=np.float32)
-
-    # threshhold images and normalize colors
-    images_colors = map(handle_channel, channels)
-    images_colors = list(images_colors)
-    total = len(images_colors)
-
-    # colorize image
-    for color_idx in range(3):
-        for image, color in images_colors:
-
-            # Add color for one channel in image buffer
-            image_buffer += image * color[color_idx]
-
-        np.round(image_buffer/total, out=image_buffer)
-
-        # Write to output and reset buffer
-        image_out[:, :, color_idx] = np.uint8(image_buffer)
-        image_buffer *= 0
-
-    return image_out
+    return out_buffer / num_channels

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -2,17 +2,19 @@ import numpy as np
 import skimage.exposure
 
 
-def composite_channel(a, image, color, range_min, range_max, out=None):
-    ''' Composite given image _a_ with rendered channel _image_
+def composite_channel(target, image, color, range_min, range_max, out=None):
+    ''' Render _image_ in pseudocolor and composite into _target_
 
-    To update _a_ destructively, pass the same array to _a_ and _out_.
+    By default, a new output array will be allocated to hold
+    the result of the composition operation. To update _target_
+    in place instead, specify the same array for _target_ and _out_.
 
     Args:
-        a: Numpy array to composite
-        image: Numpy array of channel to render and composite
-        color: Color as r, g, b float32 array within 0, 1
-        range_min: Threshhold range minimum, float32 within 0, 1
-        range_max: Threshhold range maximum, float32 within 0, 1
+        target: Numpy array containing composition target image
+        image: Numpy array of image to render and composite
+        color: Color as r, g, b float array within 0, 1
+        range_min: Threshhold range minimum, float within 0, 1
+        range_max: Threshhold range maximum, float within 0, 1
         out: Optional output numpy array in which to place the result.
 
     Returns:
@@ -21,7 +23,7 @@ def composite_channel(a, image, color, range_min, range_max, out=None):
     '''
 
     if out is None:
-        out = a.copy()
+        out = target.copy()
 
     # Rescale the new channel to a float64 between 0 and 1
     f64_range = (range_min, range_max)
@@ -43,14 +45,15 @@ def composite_channels(channels):
             list must have the following rendering settings:
             {
                 image: Numpy 2D image data of any type
-                color: Color as r, g, b float32 array within 0, 1
-                min: Threshhold range minimum, float32 within 0, 1
-                max: Threshhold range maximum, float32 within 0, 1
+                color: Color as r, g, b float array within 0, 1
+                min: Threshhold range minimum, float within 0, 1
+                max: Threshhold range maximum, float within 0, 1
             }
 
     Returns:
-        An r, g, b float32 color image. Each color component has the same \
-shape as each image in channels with color component values within 0, 1.
+        For input images with shape `(n,m)`,
+        returns a float32 RGB color image with shape
+        `(n,m,3)` and values in the range 0 to 1
     '''
 
     num_channels = len(channels)

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -36,10 +36,11 @@ def composite_channel(a, image, color, range_min, range_max, out=None):
 
 
 def composite_channels(channels):
-    '''Blend all channels into one normalized image
+    '''Render each image in _channels_ additively into a composited image
 
-    Arguments:
-        channels: List of dicts of channels to blend with rendering settings:
+    Args:
+        channels: List of dicts for channels to blend. Each dict in the
+            list must have the following rendering settings:
             {
                 image: Numpy 2D image data of any type
                 color: Color as r, g, b float32 array within 0, 1

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -79,7 +79,7 @@ def composite_channels(channels):
 
         # Add all three channels to output buffer
         args = map(channel.get, ['image', 'color', 'min', 'max'])
-        out_buffer = composite_channel(out_buffer, *args, out=out_buffer)
+        composite_channel(out_buffer, *args, out=out_buffer)
 
     # Return gamma correct image within 0, 1
     np.clip(out_buffer, 0, 1, out=out_buffer)

--- a/src/minerva_lib/blend.py
+++ b/src/minerva_lib/blend.py
@@ -16,14 +16,11 @@ def handle_channel(channel):
         Threshholded float32 image normalzied within 0, 1
         r, g, b float32 array color within 0, 1
     '''
-    image = channel['image']
-    min_ = channel['min']
-    max_ = channel['max']
+    f32_range = (channel['min'], channel['max'])
+    f32_image = skimage.img_as_float(channel['image'])
 
-    # Return image for additive blending
-    f32_image = skimage.img_as_float(image)
-    f32_image = skimage.exposure.rescale_intensity(f32_image, (min_, max_))
-
+    # Return rescaled image and color for additive blending
+    f32_image = skimage.exposure.rescale_intensity(f32_image, f32_range)
     return f32_image, channel['color']
 
 

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -7,12 +7,12 @@ from minerva_lib.blend import composite_channel, composite_channels
 
 @pytest.fixture
 def full_u8():
-    return int(255)
+    return 255
 
 
 @pytest.fixture
 def full_u16():
-    return int(65535)
+    return 65535
 
 
 @pytest.fixture
@@ -72,22 +72,17 @@ def colors(request):
 
 
 @pytest.fixture
-def u16_low_med_high(full_u8, full_u16):
+def u16_3value_channel(full_u8, full_u16):
     return np.array([[0], [full_u8], [full_u16]], dtype=np.uint16)
 
 
 @pytest.fixture
-def f32_low_med_high(full_u8, full_u16):
-    return np.array([[0], [full_u8 / full_u16], [1]], dtype=np.float32)
-
-
-@pytest.fixture
-def f32_buffer():
+def f32_3value_rgb_buffer():
     return np.zeros((3, 1, 3), dtype=np.float32)
 
 
 @pytest.fixture
-def channel_checkered(full_u16):
+def u16_checkered_channel(full_u16):
     return np.array([
         [0, full_u16],
         [full_u16, 0]
@@ -95,15 +90,15 @@ def channel_checkered(full_u16):
 
 
 @pytest.fixture
-def channel_checkered_inverse(full_u16):
+def u16_checkered_channel_inverse(full_u16):
     return np.array([
         [full_u16, 0],
         [0, full_u16]
     ], dtype=np.uint16)
 
 
-def test_channel_range_high(u16_low_med_high, color_white, range_high,
-                            f32_buffer):
+def test_channel_range_high(u16_3value_channel, color_white, range_high,
+                            f32_3value_rgb_buffer):
     '''Extract high values from image in channel dictionary'''
 
     expected = np.array([
@@ -112,8 +107,8 @@ def test_channel_range_high(u16_low_med_high, color_white, range_high,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_white,
         'min': range_high[0],
         'max': range_high[1]
@@ -122,8 +117,8 @@ def test_channel_range_high(u16_low_med_high, color_white, range_high,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channel_range_low(u16_low_med_high, color_white, range_low,
-                           f32_buffer):
+def test_channel_range_low(u16_3value_channel, color_white, range_low,
+                           f32_3value_rgb_buffer):
     '''Extract low values from image in channel dictionary'''
 
     expected = np.array([
@@ -132,8 +127,8 @@ def test_channel_range_low(u16_low_med_high, color_white, range_low,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_white,
         'min': range_low[0],
         'max': range_low[1]
@@ -142,8 +137,8 @@ def test_channel_range_low(u16_low_med_high, color_white, range_low,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channel_color_red(u16_low_med_high, color_red, range_all,
-                           f32_buffer):
+def test_channel_color_red(u16_3value_channel, color_red, range_all,
+                           f32_3value_rgb_buffer):
     '''Blend an image with one channel, testing red color'''
 
     expected = np.array([
@@ -152,8 +147,8 @@ def test_channel_color_red(u16_low_med_high, color_red, range_all,
         [[1, 0, 0]]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_red,
         'min': range_all[0],
         'max': range_all[1]
@@ -162,8 +157,8 @@ def test_channel_color_red(u16_low_med_high, color_red, range_all,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channel_color_white(u16_low_med_high, color_white, range_all,
-                             f32_buffer):
+def test_channel_color_white(u16_3value_channel, color_white, range_all,
+                             f32_3value_rgb_buffer):
     '''Blend an image with one channel, testing white color'''
 
     expected = np.array([
@@ -172,8 +167,8 @@ def test_channel_color_white(u16_low_med_high, color_white, range_all,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_white,
         'min': range_all[0],
         'max': range_all[1]
@@ -182,8 +177,8 @@ def test_channel_color_white(u16_low_med_high, color_white, range_all,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channel_color_khaki(u16_low_med_high, color_khaki, range_all,
-                             f32_buffer):
+def test_channel_color_khaki(u16_3value_channel, color_khaki, range_all,
+                             f32_3value_rgb_buffer):
     '''Make an image with one channel, testing khaki color
     Ensure any color mappings normalize between 0 and 1
     '''
@@ -194,8 +189,8 @@ def test_channel_color_khaki(u16_low_med_high, color_khaki, range_all,
         [color_khaki]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_khaki,
         'min': range_all[0],
         'max': range_all[1]
@@ -204,8 +199,8 @@ def test_channel_color_khaki(u16_low_med_high, color_khaki, range_all,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channel_khaki_low(u16_low_med_high, color_khaki, range_low,
-                           f32_buffer):
+def test_channel_khaki_low(u16_3value_channel, color_khaki, range_low,
+                           f32_3value_rgb_buffer):
     '''Blend an image with one channel, testing khaki at low range
     Ensure overly bright values are clipped to 1
     '''
@@ -216,8 +211,8 @@ def test_channel_khaki_low(u16_low_med_high, color_khaki, range_low,
         [color_khaki],
     ], dtype=np.float32)
 
-    result = composite_channel(f32_buffer, {
-        'image': u16_low_med_high,
+    result = composite_channel(f32_3value_rgb_buffer, {
+        'image': u16_3value_channel,
         'color': color_khaki,
         'min': range_low[0],
         'max': range_low[1]
@@ -226,7 +221,8 @@ def test_channel_khaki_low(u16_low_med_high, color_khaki, range_low,
     np.testing.assert_allclose(expected, result)
 
 
-def test_channels_two_channel(channel_checkered, channel_checkered_inverse,
+def test_channels_two_channel(u16_checkered_channel,
+                              u16_checkered_channel_inverse,
                               color_blue, color_yellow, range_all):
     '''Test blending an image with two channels'''
 
@@ -237,13 +233,13 @@ def test_channels_two_channel(channel_checkered, channel_checkered_inverse,
 
     result = composite_channels([
         {
-            'image': channel_checkered,
+            'image': u16_checkered_channel,
             'color': color_blue,
             'min': range_all[0],
             'max': range_all[1]
         },
         {
-            'image': channel_checkered_inverse,
+            'image': u16_checkered_channel_inverse,
             'color': color_yellow,
             'min': range_all[0],
             'max': range_all[1]

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -155,9 +155,9 @@ def test_color_white(channel_low_med_high, range_all, color_white):
 
     expected = np.array([
         [[0, 0, 0]],
-        [[255, 255, 255]],
-        [[65535, 65535, 65535]]
-    ], dtype=np.float32) / 65535
+        [color_white * 255 / 65535],
+        [color_white]
+    ], dtype=np.float32) ** (1 / 2.2)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -174,9 +174,9 @@ def test_color_red(channel_low_med_high, range_all, color_red):
 
     expected = np.array([
         [[0, 0, 0]],
-        [[255, 0, 0]],
-        [[65535, 0, 0]]
-    ], dtype=np.float32) / 65535
+        [[255 / 65535, 0, 0]],
+        [[1, 0, 0]]
+    ], dtype=np.float32) ** (1 / 2.2)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -195,9 +195,9 @@ def test_color_khaki(channel_low_med_high, range_all, color_khaki):
 
     expected = np.array([
         [[0, 0, 0]],
-        [color_khaki * 255],
-        [color_khaki * 65535]
-    ], dtype=np.float32) / 65535
+        [color_khaki * 255 / 65535],
+        [color_khaki]
+    ], dtype=np.float32) ** (1 / 2.2)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -218,7 +218,7 @@ def test_color_khaki_range_low(channel_low_med_high, range_low, color_khaki):
         [[0, 0, 0]],
         [color_khaki],
         [color_khaki],
-    ], dtype=np.float32)
+    ], dtype=np.float32) ** (1 / 2.2)
 
     result = linear_rgb([{
         'image': channel_low_med_high,

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -97,12 +97,8 @@ def test_channel_range_high(u16_3value_channel, color_white, range_high,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_white,
-        'min': range_high[0],
-        'max': range_high[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_white, *range_high)
 
     np.testing.assert_allclose(expected, result)
 
@@ -117,12 +113,8 @@ def test_channel_range_low(u16_3value_channel, color_white, range_low,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_white,
-        'min': range_low[0],
-        'max': range_low[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_white, *range_low)
 
     np.testing.assert_allclose(expected, result)
 
@@ -137,12 +129,8 @@ def test_channel_color_red(u16_3value_channel, color_red, range_all,
         [[1, 0, 0]]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_red,
-        'min': range_all[0],
-        'max': range_all[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_red, *range_all)
 
     np.testing.assert_allclose(expected, result)
 
@@ -157,12 +145,8 @@ def test_channel_color_white(u16_3value_channel, color_white, range_all,
         [color_white]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_white,
-        'min': range_all[0],
-        'max': range_all[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_white, *range_all)
 
     np.testing.assert_allclose(expected, result)
 
@@ -179,12 +163,8 @@ def test_channel_color_khaki(u16_3value_channel, color_khaki, range_all,
         [color_khaki]
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_khaki,
-        'min': range_all[0],
-        'max': range_all[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_khaki, *range_all)
 
     np.testing.assert_allclose(expected, result)
 
@@ -201,12 +181,8 @@ def test_channel_khaki_low(u16_3value_channel, color_khaki, range_low,
         [color_khaki],
     ], dtype=np.float32)
 
-    result = composite_channel(f32_3value_rgb_buffer, {
-        'image': u16_3value_channel,
-        'color': color_khaki,
-        'min': range_low[0],
-        'max': range_low[1]
-    })
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_khaki, *range_low)
 
     np.testing.assert_allclose(expected, result)
 

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -18,17 +18,17 @@ def full_u16():
 
 @pytest.fixture
 def range_all():
-    return np.float32([0, 1])
+    return np.array([0, 1], dtype=np.float32)
 
 
 @pytest.fixture
 def range_high():
-    return np.float32([0.5, 1])
+    return np.array([0.5, 1], dtype=np.float32)
 
 
 @pytest.fixture
 def range_low(full_u8, full_u16):
-    return np.float32([0, full_u8 / full_u16])
+    return np.array([0, full_u8 / full_u16], dtype=np.float32)
 
 
 @pytest.fixture(params=['range_all', 'range_high', 'range_low'])
@@ -38,32 +38,32 @@ def ranges(request):
 
 @pytest.fixture
 def color_white():
-    return np.float32([1, 1, 1])
+    return np.array([1, 1, 1], dtype=np.float32)
 
 
 @pytest.fixture
 def color_yellow():
-    return np.float32([1, 1, 0])
+    return np.array([1, 1, 0], dtype=np.float32)
 
 
 @pytest.fixture
 def color_green():
-    return np.float32([0, 1, 0])
+    return np.array([0, 1, 0], dtype=np.float32)
 
 
 @pytest.fixture
 def color_blue():
-    return np.float32([0, 0, 1])
+    return np.array([0, 0, 1], dtype=np.float32)
 
 
 @pytest.fixture
 def color_red():
-    return np.float32([1, 0, 0])
+    return np.array([1, 0, 0], dtype=np.float32)
 
 
 @pytest.fixture
 def color_khaki(full_u8):
-    return np.float32([240, 230, 140]) / full_u8
+    return np.array([240, 230, 140], dtype=np.float32) / full_u8
 
 
 @pytest.fixture(params=['color_white', 'color_yellow', 'color_green',
@@ -74,31 +74,31 @@ def colors(request):
 
 @pytest.fixture
 def channel_low_med_high(full_u8, full_u16):
-    return np.uint16([[0], [full_u8], [full_u16]])
+    return np.array([[0], [full_u8], [full_u16]], dtype=np.uint16)
 
 
 @pytest.fixture
 def channel_check(full_u16):
-    return np.uint16([
+    return np.array([
         [0, full_u16],
         [full_u16, 0]
-    ])
+    ], dtype=np.uint16)
 
 
 @pytest.fixture
 def channel_check_inverse(full_u16):
-    return np.uint16([
+    return np.array([
         [full_u16, 0],
         [0, full_u16]
-    ])
+    ], dtype=np.uint16)
 
 
 def test_handle_channel(channel_low_med_high, color_white, range_high):
     '''Extract scaled color and threshholded image from channel dictionary'''
 
     expected = (
-        np.float32([[0], [0], [1]]),
-        np.float32([1, 1, 1])
+        np.array([[0], [0], [1]], dtype=np.float32),
+        np.array([1, 1, 1], dtype=np.float32)
     )
 
     result = handle_channel({
@@ -115,11 +115,11 @@ def test_handle_channel(channel_low_med_high, color_white, range_high):
 def test_range_high(channel_low_med_high, color_white, range_high):
     '''Blend an image with one channel, testing high range'''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [[0, 0, 0]],
         [[1, 1, 1]]
-    ])
+    ], dtype=np.float32)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -134,11 +134,11 @@ def test_range_high(channel_low_med_high, color_white, range_high):
 def test_range_low(channel_low_med_high, color_white, range_low):
     '''Blend an image with one channel, testing low range'''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [[1, 1, 1]],
         [[1, 1, 1]]
-    ])
+    ], dtype=np.float32)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -153,11 +153,11 @@ def test_range_low(channel_low_med_high, color_white, range_low):
 def test_color_white(channel_low_med_high, range_all, color_white):
     '''Blend an image with one channel, testing white color'''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [[255, 255, 255]],
         [[65535, 65535, 65535]]
-    ]) / 65535
+    ], dtype=np.float32) / 65535
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -172,11 +172,11 @@ def test_color_white(channel_low_med_high, range_all, color_white):
 def test_color_red(channel_low_med_high, range_all, color_red):
     '''Blend an image with one channel, testing red color'''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [[255, 0, 0]],
         [[65535, 0, 0]]
-    ]) / 65535
+    ], dtype=np.float32) / 65535
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -193,11 +193,11 @@ def test_color_khaki(channel_low_med_high, range_all, color_khaki):
     Colors of any lightness/chroma should correctly normalize
     '''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [color_khaki * 255],
         [color_khaki * 65535]
-    ]) / 65535
+    ], dtype=np.float32) / 65535
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -214,11 +214,11 @@ def test_color_khaki_range_low(channel_low_med_high, range_low, color_khaki):
     Colors of any lightness/chroma should set all over max to 1
     '''
 
-    expected = np.float32([
+    expected = np.array([
         [[0, 0, 0]],
         [color_khaki],
         [color_khaki],
-    ])
+    ], dtype=np.float32)
 
     result = linear_rgb([{
         'image': channel_low_med_high,
@@ -234,10 +234,10 @@ def test_multi_channel(channel_check, channel_check_inverse, range_all,
                        color_blue, color_yellow):
     '''Test blending an image with multiple channels'''
 
-    expected = 1.0 * np.float32([
+    expected = np.array([
         [color_yellow, color_blue],
         [color_blue, color_yellow],
-    ])
+    ], dtype=np.float32)
 
     result = linear_rgb([
         {
@@ -262,13 +262,13 @@ def test_channel_size_mismatch(range_all, color_white):
 
     input_channels = [
         {
-            'image': np.uint16([[0, 0, 0]]),
+            'image': np.array([[0, 0, 0]], dtype=np.uint16),
             'color': color_white,
             'min': range_all[0],
             'max': range_all[1]
         },
         {
-            'image': np.uint16([[0, 65535]]),
+            'image': np.array([[0, 65535]], dtype=np.uint16),
             'color': color_white,
             'min': range_all[0],
             'max': range_all[1]

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -103,8 +103,8 @@ def test_clip_image_range_all(u16_low_med_high, color_white, range_all):
     '''Extract high values from image in channel dictionary'''
 
     expected = (
-        np.array([[0], [255 / 65535], [1]], dtype=np.float32),
-        np.array([1, 1, 1], dtype=np.float32)
+        np.array([[0], [255 / 65535], [1]], dtype=np.float64),
+        np.array([1, 1, 1], dtype=np.float64)
     )
 
     result = clip_image({
@@ -114,7 +114,7 @@ def test_clip_image_range_all(u16_low_med_high, color_white, range_all):
         'max': range_all[1]
     })
 
-    assert np.allclose(expected[0], result[0], 10e-13, 10e-13)
+    np.testing.assert_array_equal(expected[0], result[0])
     np.testing.assert_array_equal(expected[1], result[1])
 
 
@@ -122,8 +122,8 @@ def test_clip_image_range_high(u16_low_med_high, color_white, range_high):
     '''Extract high values from image in channel dictionary'''
 
     expected = (
-        np.array([[0], [0], [1]], dtype=np.float32),
-        np.array([1, 1, 1], dtype=np.float32)
+        np.array([[0], [0], [1]], dtype=np.float64),
+        np.array([1, 1, 1], dtype=np.float64)
     )
 
     result = clip_image({
@@ -141,8 +141,8 @@ def test_clip_image_range_low(u16_low_med_high, color_white, range_low):
     '''Extract low values from image in channel dictionary'''
 
     expected = (
-        np.array([[0], [1], [1]], dtype=np.float32),
-        np.array([1, 1, 1], dtype=np.float32)
+        np.array([[0], [1], [1]], dtype=np.float64),
+        np.array([1, 1, 1], dtype=np.float64)
     )
 
     result = clip_image({

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -262,7 +262,7 @@ def test_channel_size_mismatch(range_all, color_white):
 
     input_channels = [
         {
-            'image': np.uint16([[0]]),
+            'image': np.uint16([[0, 0, 0]]),
             'color': color_white,
             'min': range_all[0],
             'max': range_all[1]
@@ -276,7 +276,7 @@ def test_channel_size_mismatch(range_all, color_white):
     ]
 
     with pytest.raises(ValueError,
-                       match=r'non-broadcastable output operand .*'):
+                       match=r'.*broadcast.*'):
         linear_rgb(input_channels)
 
 

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -151,6 +151,17 @@ def test_channel_color_white(u16_3value_channel, color_white, range_all,
     np.testing.assert_allclose(expected, result)
 
 
+def test_channel_target_is_out(u16_3value_channel, color_white, range_all,
+                               f32_3value_rgb_buffer):
+    '''Blend an image in place by providing an output argument'''
+
+    result = composite_channel(f32_3value_rgb_buffer, u16_3value_channel,
+                               color_white, *range_all,
+                               out=f32_3value_rgb_buffer)
+
+    assert f32_3value_rgb_buffer is result
+
+
 def test_channel_color_khaki(u16_3value_channel, color_khaki, range_all,
                              f32_3value_rgb_buffer):
     '''Make an image with one channel, testing khaki color

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -234,7 +234,7 @@ def test_multi_channel(channel_check, channel_check_inverse, range_all,
                        color_blue, color_yellow):
     '''Test blending an image with multiple channels'''
 
-    expected = 0.5 * np.float32([
+    expected = 1.0 * np.float32([
         [color_yellow, color_blue],
         [color_blue, color_yellow],
     ])

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 from minerva_lib.blend import handle_channel
-from minerva_lib.blend import linear_bgr
+from minerva_lib.blend import linear_rgb
 
 
 @pytest.fixture
@@ -121,7 +121,7 @@ def test_range_high(channel_low_med_high, color_white, range_high):
         [[1, 1, 1]]
     ])
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_white,
         'min': range_high[0],
@@ -140,7 +140,7 @@ def test_range_low(channel_low_med_high, color_white, range_low):
         [[1, 1, 1]]
     ])
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_white,
         'min': range_low[0],
@@ -159,7 +159,7 @@ def test_color_white(channel_low_med_high, range_all, color_white):
         [[65535, 65535, 65535]]
     ]) / 65535
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_white,
         'min': range_all[0],
@@ -178,7 +178,7 @@ def test_color_red(channel_low_med_high, range_all, color_red):
         [[65535, 0, 0]]
     ]) / 65535
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_red,
         'min': range_all[0],
@@ -199,7 +199,7 @@ def test_color_khaki(channel_low_med_high, range_all, color_khaki):
         [color_khaki * 65535]
     ]) / 65535
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_khaki,
         'min': range_all[0],
@@ -220,7 +220,7 @@ def test_color_khaki_range_low(channel_low_med_high, range_low, color_khaki):
         [color_khaki],
     ])
 
-    result = linear_bgr([{
+    result = linear_rgb([{
         'image': channel_low_med_high,
         'color': color_khaki,
         'min': range_low[0],
@@ -239,7 +239,7 @@ def test_multi_channel(channel_check, channel_check_inverse, range_all,
         [color_blue, color_yellow],
     ])
 
-    result = linear_bgr([
+    result = linear_rgb([
         {
             'image': channel_check,
             'color': color_blue,
@@ -277,7 +277,7 @@ def test_channel_size_mismatch(range_all, color_white):
 
     with pytest.raises(ValueError,
                        match=r'non-broadcastable output operand .*'):
-        linear_bgr(input_channels)
+        linear_rgb(input_channels)
 
 
 def test_channel_size_zero():
@@ -285,4 +285,4 @@ def test_channel_size_zero():
 
     with pytest.raises(ValueError,
                        match=r'At least one channel must be specified'):
-        linear_bgr([])
+        linear_rgb([])

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -6,16 +6,6 @@ from minerva_lib.blend import composite_channel, composite_channels
 
 
 @pytest.fixture
-def full_u8():
-    return 255
-
-
-@pytest.fixture
-def full_u16():
-    return 65535
-
-
-@pytest.fixture
 def range_all():
     return np.array([0, 1], dtype=np.float32)
 
@@ -26,8 +16,8 @@ def range_high():
 
 
 @pytest.fixture
-def range_low(full_u8, full_u16):
-    return np.array([0, full_u8 / full_u16], dtype=np.float32)
+def range_low():
+    return np.array([0, 12345 / 65535], dtype=np.float32)
 
 
 @pytest.fixture(params=['range_all', 'range_high', 'range_low'])
@@ -61,8 +51,8 @@ def color_red():
 
 
 @pytest.fixture
-def color_khaki(full_u8):
-    return np.array([240, 230, 140], dtype=np.float32) / full_u8
+def color_khaki():
+    return np.array([240, 230, 140], dtype=np.float32) / 255
 
 
 @pytest.fixture(params=['color_white', 'color_yellow', 'color_green',
@@ -72,8 +62,8 @@ def colors(request):
 
 
 @pytest.fixture
-def u16_3value_channel(full_u8, full_u16):
-    return np.array([[0], [full_u8], [full_u16]], dtype=np.uint16)
+def u16_3value_channel():
+    return np.array([[0], [12345], [65535]], dtype=np.uint16)
 
 
 @pytest.fixture
@@ -82,18 +72,18 @@ def f32_3value_rgb_buffer():
 
 
 @pytest.fixture
-def u16_checkered_channel(full_u16):
+def u16_checkered_channel():
     return np.array([
-        [0, full_u16],
-        [full_u16, 0]
+        [0, 65535],
+        [65535, 0]
     ], dtype=np.uint16)
 
 
 @pytest.fixture
-def u16_checkered_channel_inverse(full_u16):
+def u16_checkered_channel_inverse():
     return np.array([
-        [full_u16, 0],
-        [0, full_u16]
+        [65535, 0],
+        [0, 65535]
     ], dtype=np.uint16)
 
 
@@ -143,7 +133,7 @@ def test_channel_color_red(u16_3value_channel, color_red, range_all,
 
     expected = np.array([
         [[0, 0, 0]],
-        [[255 / 65535, 0, 0]],
+        [[12345 / 65535, 0, 0]],
         [[1, 0, 0]]
     ], dtype=np.float32)
 
@@ -163,7 +153,7 @@ def test_channel_color_white(u16_3value_channel, color_white, range_all,
 
     expected = np.array([
         [[0, 0, 0]],
-        [color_white * 255 / 65535],
+        [color_white * 12345 / 65535],
         [color_white]
     ], dtype=np.float32)
 
@@ -185,7 +175,7 @@ def test_channel_color_khaki(u16_3value_channel, color_khaki, range_all,
 
     expected = np.array([
         [[0, 0, 0]],
-        [color_khaki * 255 / 65535],
+        [color_khaki * 12345 / 65535],
         [color_khaki]
     ], dtype=np.float32)
 

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -178,7 +178,7 @@ def test_range_low(channel_low_med_high, color_white, range_low):
     expected = np.uint8([
         [[0, 0, 0]],
         [[255, 255, 255]],
-        [[0, 0, 0]]
+        [[255, 255, 255]]
     ])
 
     result = linear_bgr([{
@@ -252,13 +252,13 @@ def test_color_khaki(channel_low_med_high, range_all, color_khaki):
 
 def test_color_khaki_range_low(channel_low_med_high, range_low, color_khaki):
     '''Blend an image with one channel, testing khaki at low range
-    Colors of any lightness/chroma should map inputs above threshhold to 0
+    Colors of any lightness/chroma should max out inputs above threshhold
     '''
 
     expected = np.uint8([
         [[0, 0, 0]],
         [[140, 230, 240]],
-        [[0, 0, 0]]
+        [[140, 230, 240]]
     ])
 
     result = linear_bgr([{

--- a/tests/blend.py
+++ b/tests/blend.py
@@ -2,9 +2,20 @@
 
 import pytest
 import numpy as np
-from minerva_lib.blend import to_f32
-from minerva_lib.blend import f32_to_bgr
+from minerva_lib.blend import threshhold_image
+from minerva_lib.blend import handle_channel
+from minerva_lib.blend import scale_color
 from minerva_lib.blend import linear_bgr
+
+
+@pytest.fixture
+def half_uint16():
+    return int(32768)
+
+
+@pytest.fixture
+def full_uint16():
+    return int(65535)
 
 
 @pytest.fixture
@@ -64,15 +75,6 @@ def colors(request):
 
 
 @pytest.fixture
-def f32_channel_low_med_high():
-    return np.float32([
-        [0.0],
-        [256.0 / 65535.0],
-        [1.0],
-    ])
-
-
-@pytest.fixture
 def channel_low_med_high():
     return np.uint16([[0], [256], [65535]])
 
@@ -91,6 +93,45 @@ def channel_check_inverse():
         [65535, 0],
         [0, 65535]
     ])
+
+
+def test_scale_color(color_white, half_uint16, full_uint16):
+    '''Make color into conversion factor from uint16 to uint8 bgr'''
+
+    expected = np.float32([255, 255, 255]) / 32767
+
+    result = scale_color(color_white, full_uint16 - half_uint16)
+
+    np.testing.assert_array_equal(expected, result)
+
+
+def test_threshhold_image(channel_low_med_high, half_uint16, full_uint16):
+    '''Threshhold image within upper half of the unsigned 16-bit range'''
+
+    expected = np.uint16([[0], [0], [32767]])
+
+    threshhold_image(channel_low_med_high, half_uint16, full_uint16)
+
+    np.testing.assert_array_equal(expected, channel_low_med_high)
+
+
+def test_handle_channel(channel_low_med_high, color_white, range_high):
+    '''Extract scaled color and threshholded image from channel dictionary'''
+
+    expected = (
+        np.uint16([[0], [0], [32767]]),
+        np.float32([255, 255, 255]) / 32767
+    )
+
+    result = handle_channel({
+        'image': channel_low_med_high,
+        'color': color_white,
+        'min': range_high[0],
+        'max': range_high[1]
+    })
+
+    np.testing.assert_array_equal(expected[0], result[0])
+    np.testing.assert_array_equal(expected[1], result[1])
 
 
 def test_range_all(channel_low_med_high, color_white, range_all):
@@ -286,57 +327,3 @@ def test_channel_size_zero():
     with pytest.raises(ValueError,
                        match=r'At least one channel must be specified'):
         linear_bgr([])
-
-
-def test_to_f32_full(channel_low_med_high, f32_channel_low_med_high):
-    ''' Test conversion to f32 across uint16 range'''
-
-    expected = f32_channel_low_med_high
-    result = to_f32(channel_low_med_high)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_to_f32_float_input(f32_channel_low_med_high):
-    '''Test supplying floating points when unsigned integers are expected'''
-
-    with pytest.raises(ValueError,
-                       match=r'Scaling to 0,1 requires unsigned integers'):
-        to_f32(f32_channel_low_med_high)
-
-
-def test_f32_to_bgr_white(channel_low_med_high, f32_channel_low_med_high):
-    ''' Test conversion from f32 to black, gray, white'''
-
-    expected = np.uint8([
-        [[0, 0, 0]],
-        [[1, 1, 1]],
-        [[255, 255, 255]]
-    ])
-
-    result = f32_to_bgr(f32_channel_low_med_high)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_f32_to_bgr_yellow(color_yellow, channel_low_med_high,
-                           f32_channel_low_med_high):
-    ''' Test conversion from f32 to yellow gradient'''
-
-    expected = np.uint8([
-        [[0, 0, 0]],
-        [[0, 1, 1]],
-        [[0, 255, 255]]
-    ])
-
-    result = f32_to_bgr(f32_channel_low_med_high, color_yellow)
-
-    np.testing.assert_array_equal(expected, result)
-
-
-def test_f32_to_bgr_int_input(channel_low_med_high):
-    '''Test supplying floating points when unsigned integers are expected'''
-
-    with pytest.raises(ValueError,
-                       match=r'Color image requires values from 0,1'):
-        f32_to_bgr(channel_low_med_high)


### PR DESCRIPTION
This pull request address changes to `linear_bgr` implementation, interface, and tests. This pull request renames `linear_bgr` to `composite_channels`.

- The tests also now [expect the output][1] to be a float32 RGB array with values between 0 and 1. 
- The tests have been updated for [addition instead of averaging][2] when blending channels. 
- The tests now expect [values above the maximum][3] to be clipped at 1 instead of 0.

This fixes #16 
    - Values above the maximum are now set to one, not zero

This fixes #15 
    - Our tests document skimage [RBG order][0] and depend on skimage for threshholding/normalization

This fixes #14 
    - All the input ranges and colors are clearly documented as within 0, 1

This fixes #18 
    - All tests construct typed arrays using `np.array(*, dtype=*)`

While the input argument `channels` must be a list, the function `composite_channel` can be used in a custom implementation of a function such as `composite_channels` to handle iterators and queues. 
 
[0]: https://github.com/sorgerlab/minerva-lib-python/pull/17/commits/30cf6178ef824d12a020e23251c55531958bb4c0#diff-4438daa1ceea9cdeeef65ab8cfb5075dL46
[1]: https://github.com/sorgerlab/minerva-lib-python/pull/17/commits/30cf6178ef824d12a020e23251c55531958bb4c0#diff-4438daa1ceea9cdeeef65ab8cfb5075dL159
[2]: https://github.com/sorgerlab/minerva-lib-python/pull/17/commits/0b1f59c260dc182da4fde1c30a42867fab1b1b4b#diff-4438daa1ceea9cdeeef65ab8cfb5075dL237
[3]: https://github.com/sorgerlab/minerva-lib-python/pull/17/commits/0e6f4b0d4138100679bae738abf5dfb41bc6bc73#diff-4438daa1ceea9cdeeef65ab8cfb5075dL258